### PR TITLE
fixes issue #1: slashes in IDs not encoded.

### DIFF
--- a/attachments.go
+++ b/attachments.go
@@ -27,7 +27,7 @@ func (db *DB) Attachment(docid, name, rev string) (*Attachment, error) {
 		return nil, fmt.Errorf("couchdb.GetAttachment: empty attachment Name")
 	}
 
-	resp, err := db.request("GET", revpath(rev, db.name, docid, name), nil)
+	resp, err := db.request("GET", revpath(rev, encid(db.name), encid(docid), name), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -51,7 +51,7 @@ func (db *DB) AttachmentMeta(docid, name, rev string) (*Attachment, error) {
 		return nil, fmt.Errorf("couchdb.GetAttachment: empty attachment Name")
 	}
 
-	path := revpath(rev, db.name, docid, name)
+	path := revpath(rev, encid(db.name), encid(docid), name)
 	resp, err := db.closedRequest("HEAD", path, nil)
 	if err != nil {
 		return nil, err
@@ -72,7 +72,7 @@ func (db *DB) PutAttachment(docid string, att *Attachment, rev string) (newrev s
 		return rev, fmt.Errorf("couchdb.PutAttachment: nil attachment Body")
 	}
 
-	path := revpath(rev, db.name, docid, att.Name)
+	path := revpath(rev, encid(db.name), encid(docid), att.Name)
 	req, err := db.newRequest("PUT", path, att.Body)
 	if err != nil {
 		return rev, err
@@ -100,7 +100,7 @@ func (db *DB) DeleteAttachment(docid, name, rev string) (newrev string, err erro
 		return rev, fmt.Errorf("couchdb.PutAttachment: empty name")
 	}
 
-	path := revpath(rev, db.name, docid, name)
+	path := revpath(rev, encid(db.name), encid(docid), name)
 	resp, err := db.closedRequest("DELETE", path, nil)
 	return responseRev(resp, err)
 }

--- a/couchdb.go
+++ b/couchdb.go
@@ -124,6 +124,19 @@ var getJsonKeys = []string{"open_revs", "atts_since"}
 //
 // http://docs.couchdb.org/en/latest/api/document/common.html?highlight=doc#get--db-docid
 func (db *DB) Get(id string, doc interface{}, opts Options) error {
+	// issue #1: slashes in document IDs need to be escaped.
+	// ref: http://wiki.apache.org/couchdb/HTTP_Document_API#line-75
+	const DDOC_PREFIX = "_design"
+	segments := strings.Split(id, "/")
+	if len(segments) > 1 {
+		if segments[0] == DDOC_PREFIX {
+			// preferred encoding for design docs is _design/seg1%2Fseg2
+			id = segments[0] + "/" + strings.Join(segments[1:], "%2F")
+		} else {
+			id = strings.Join(segments, "%2F")
+		}
+	}
+
 	path, err := optpath(opts, getJsonKeys, db.name, id)
 	if err != nil {
 		return err

--- a/couchdb_test.go
+++ b/couchdb_test.go
@@ -202,6 +202,60 @@ func TestGetExistingDoc(t *testing.T) {
 	check(t, "doc.Field", int64(999), doc.Field)
 }
 
+func TestGetExistingDocWithSlashInId(t *testing.T) {
+	c := newTestClient(t)
+	c.Handle("GET /db/doc%2Fslash", func(resp ResponseWriter, req *Request) {
+		io.WriteString(resp, `{
+			"_id": "doc",
+			"_rev": "1-619db7ba8551c0de3f3a178775509611",
+			"field": 999
+		}`)
+	})
+
+	var doc testDocument
+	if err := c.DB("db").Get("doc/slash", &doc, nil); err != nil {
+		t.Fatal(err)
+	}
+	check(t, "doc.Rev", "1-619db7ba8551c0de3f3a178775509611", doc.Rev)
+	check(t, "doc.Field", int64(999), doc.Field)
+}
+
+func TestGetDesignDoc(t *testing.T) {
+	c := newTestClient(t)
+	c.Handle("GET /db/_design/myddoc", func(resp ResponseWriter, req *Request) {
+		io.WriteString(resp, `{
+			"_id": "doc",
+			"_rev": "1-619db7ba8551c0de3f3a178775509611",
+			"field": 999
+		}`)
+	})
+
+	var doc testDocument
+	if err := c.DB("db").Get("_design/myddoc", &doc, nil); err != nil {
+		t.Fatal(err)
+	}
+	check(t, "doc.Rev", "1-619db7ba8551c0de3f3a178775509611", doc.Rev)
+	check(t, "doc.Field", int64(999), doc.Field)
+}
+
+func TestGetDesignDocWithSlashInId(t *testing.T) {
+	c := newTestClient(t)
+	c.Handle("GET /db/_design/myddoc%2Fslashed", func(resp ResponseWriter, req *Request) {
+		io.WriteString(resp, `{
+			"_id": "doc",
+			"_rev": "1-619db7ba8551c0de3f3a178775509611",
+			"field": 999
+		}`)
+	})
+
+	var doc testDocument
+	if err := c.DB("db").Get("_design/myddoc/slashed", &doc, nil); err != nil {
+		t.Fatal(err)
+	}
+	check(t, "doc.Rev", "1-619db7ba8551c0de3f3a178775509611", doc.Rev)
+	check(t, "doc.Field", int64(999), doc.Field)
+}
+
 func TestGetNonexistingDoc(t *testing.T) {
 	c := newTestClient(t)
 	c.Handle("GET /db/doc", func(resp ResponseWriter, req *Request) {

--- a/feeds.go
+++ b/feeds.go
@@ -140,7 +140,7 @@ type ChangesFeed struct {
 //
 // http://docs.couchdb.org/en/latest/api/database/changes.html#db-changes
 func (db *DB) Changes(options Options) (*ChangesFeed, error) {
-	path, err := optpath(options, nil, db.name, "_changes")
+	path, err := optpath(options, nil, encid(db.name), "_changes")
 	if err != nil {
 		return nil, err
 	}

--- a/x_test.go
+++ b/x_test.go
@@ -35,9 +35,13 @@ func (s *testClient) ClearHandlers() {
 }
 
 func (s *testClient) RoundTrip(req *Request) (*Response, error) {
-	handler, ok := s.handlers[req.Method+" "+req.URL.Path]
+	path := req.URL.Path
+	if path == "" {
+		path = req.URL.Opaque
+	}
+	handler, ok := s.handlers[req.Method+" "+path]
 	if !ok {
-		s.t.Fatalf("unhandled request: %s %s", req.Method, req.URL.Path)
+		s.t.Fatalf("unhandled request: %s %s", req.Method, path)
 		return nil, nil
 	}
 	recorder := httptest.NewRecorder()


### PR DESCRIPTION
This was a moderately complicated fix.  The old CouchDB wiki has this to say about slashes in document IDs:

> You can have / as part of the document ID but if you refer to a document in a URL
> you must always encode it as **%2F**. One special case is **_design/** documents, those
> accept either **/** or **%2F** for the / after _design, although / is preferred and **%2F** is still
> needed for the rest of the DocID.

(https://wiki.apache.org/couchdb/HTTP_Document_API#line-75)

I initially modified `couchdb.go` to break up the document ID on slash characters and reassemble it with `%2F` separators, with a special case for IDs that start with `_design`, where I prefixed `_design/` and assembled the rest of the ID with escaped slashes.  Here are some examples of the transformed IDs:

```
user/34734612 -> user%2F34734612
AC/DC/240V -> AC%2FDC%2F240V
_design/lookup/users -> _design/lookup%2Fusers
```

I added new unit tests to `couchdb_test.go` with handlers that responded to the escaped document IDs and found that these tests failed.  After some investigation, I found [issue #5684](https://github.com/golang/go/issues/5684) in the golang repo, which was filed because `url.URL` was decoding escape sequences in URL paths.  My encoding code converted slashes to %2F but `url.URL` converted them back to slashes, which caused the test to fail.

The [documentation](http://godoc.org/net/url#URL) for `url.URL` contained a workaround for this issue: the `Opaque` field of a `URL` struct can be set with the value of the encoded URL path, and that encoded value will be used in `http.Request` as the request path.  Unfortunately, this involved replacing the call to `http.NewRequest` in the `newRequest` function with code that constructs a `Request` structure manually.  This is the part of the PR that should be reviewed most strictly to make sure I didn't inadvertently miss anything in the request construction.  All the unit tests, including my new ones that test getting document IDs containing slashes, are passing.

Let me know what you think or if there is anything I can do to improve this code.
