### PR TITLE
Do not close the connection, just discards the body.

### DIFF
--- a/attachments_test.go
+++ b/attachments_test.go
@@ -4,11 +4,12 @@ import (
 	"bytes"
 	"encoding/base64"
 	"encoding/json"
-	"github.com/fjl/go-couchdb"
 	"io"
 	"io/ioutil"
 	. "net/http"
 	"testing"
+
+	"github.com/gwik/go-couchdb"
 )
 
 var (

--- a/auth_test.go
+++ b/auth_test.go
@@ -1,9 +1,10 @@
 package couchdb_test
 
 import (
-	"github.com/fjl/go-couchdb"
 	"net/http"
 	"testing"
+
+	"github.com/gwik/go-couchdb"
 )
 
 func TestBasicAuth(t *testing.T) {

--- a/couchapp/couchapp.go
+++ b/couchapp/couchapp.go
@@ -11,12 +11,13 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"github.com/fjl/go-couchdb"
 	"io/ioutil"
 	"mime"
 	"os"
 	"path"
 	"strings"
+
+	"github.com/gwik/go-couchdb"
 )
 
 // DefaultIgnorePatterns contains the default list of glob patterns

--- a/couchdb_test.go
+++ b/couchdb_test.go
@@ -2,7 +2,7 @@ package couchdb_test
 
 import (
 	"errors"
-	"github.com/fjl/go-couchdb"
+	"github.com/gwik/go-couchdb"
 	"io"
 	"io/ioutil"
 	. "net/http"

--- a/feeds_test.go
+++ b/feeds_test.go
@@ -1,10 +1,11 @@
 package couchdb_test
 
 import (
-	"github.com/fjl/go-couchdb"
 	"io"
 	. "net/http"
 	"testing"
+
+	"github.com/gwik/go-couchdb"
 )
 
 func TestDBUpdatesFeed(t *testing.T) {

--- a/http.go
+++ b/http.go
@@ -87,6 +87,7 @@ func (t *transport) closedRequest(method, path string, body io.Reader) (*http.Re
 	resp, err := t.request(method, path, body)
 	if err == nil {
 		io.Copy(ioutil.Discard, resp.Body)
+		resp.Body.Close()
 	}
 	return resp, err
 }

--- a/http.go
+++ b/http.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"net/http"
 	"net/url"
 	"reflect"
@@ -85,7 +86,7 @@ func (t *transport) request(method, path string, body io.Reader) (*http.Response
 func (t *transport) closedRequest(method, path string, body io.Reader) (*http.Response, error) {
 	resp, err := t.request(method, path, body)
 	if err == nil {
-		resp.Body.Close()
+		io.Copy(ioutil.Discard, resp.Body)
 	}
 	return resp, err
 }

--- a/x_test.go
+++ b/x_test.go
@@ -4,12 +4,13 @@ package couchdb_test
 
 import (
 	"bytes"
-	"github.com/fjl/go-couchdb"
 	"io/ioutil"
 	. "net/http"
 	"net/http/httptest"
 	"reflect"
 	"testing"
+
+	"github.com/gwik/go-couchdb"
 )
 
 // testClient is a very special couchdb.Client that also implements


### PR DESCRIPTION
Closing the response body closes the unlying persistent connection and exaust the local ports under high concurrency.
