### PR TITLE
Don't escape ddocs

### DIFF
--- a/attachments_test.go
+++ b/attachments_test.go
@@ -1,13 +1,12 @@
-package couchdb_test
+package couchdb
 
 import (
 	"bytes"
 	"encoding/base64"
 	"encoding/json"
-	"github.com/fjl/go-couchdb"
 	"io"
 	"io/ioutil"
-	. "net/http"
+	"net/http"
 	"testing"
 )
 
@@ -19,7 +18,7 @@ var (
 func TestAttachment(t *testing.T) {
 	c := newTestClient(t)
 	c.Handle("GET /db/doc/attachment/1",
-		func(resp ResponseWriter, req *Request) {
+		func(resp http.ResponseWriter, req *http.Request) {
 			resp.Header().Set("content-md5", "2mGd+/VXL8dJsUlrD//Xag==")
 			resp.Header().Set("content-type", "text/plain")
 			io.WriteString(resp, "the content")
@@ -43,10 +42,10 @@ func TestAttachment(t *testing.T) {
 func TestAttachmentMeta(t *testing.T) {
 	c := newTestClient(t)
 	c.Handle("HEAD /db/doc/attachment/1",
-		func(resp ResponseWriter, req *Request) {
+		func(resp http.ResponseWriter, req *http.Request) {
 			resp.Header().Set("content-md5", "2mGd+/VXL8dJsUlrD//Xag==")
 			resp.Header().Set("content-type", "text/plain")
-			resp.WriteHeader(StatusOK)
+			resp.WriteHeader(http.StatusOK)
 		})
 
 	att, err := c.DB("db").AttachmentMeta("doc", "attachment/1", "")
@@ -63,7 +62,7 @@ func TestAttachmentMeta(t *testing.T) {
 func TestPutAttachment(t *testing.T) {
 	c := newTestClient(t)
 	c.Handle("PUT /db/doc/attachment/1",
-		func(resp ResponseWriter, req *Request) {
+		func(resp http.ResponseWriter, req *http.Request) {
 			reqBodyContent, err := ioutil.ReadAll(req.Body)
 			if err != nil {
 				t.Fatal(err)
@@ -84,7 +83,7 @@ func TestPutAttachment(t *testing.T) {
 			})
 		})
 
-	att := &couchdb.Attachment{
+	att := &Attachment{
 		Name: "attachment/1",
 		Type: "text/plain",
 		Body: bytes.NewBufferString("the content"),
@@ -103,7 +102,7 @@ func TestPutAttachment(t *testing.T) {
 func TestDeleteAttachment(t *testing.T) {
 	c := newTestClient(t)
 	c.Handle("DELETE /db/doc/attachment/1",
-		func(resp ResponseWriter, req *Request) {
+		func(resp http.ResponseWriter, req *http.Request) {
 			check(t, "request query string",
 				"rev=1-619db7ba8551c0de3f3a178775509611",
 				req.URL.RawQuery)

--- a/auth_test.go
+++ b/auth_test.go
@@ -1,7 +1,6 @@
-package couchdb_test
+package couchdb
 
 import (
-	"github.com/fjl/go-couchdb"
 	"net/http"
 	"testing"
 )
@@ -16,7 +15,7 @@ func TestBasicAuth(t *testing.T) {
 
 	for _, test := range tests {
 		req, _ := http.NewRequest("GET", "http://localhost/", nil)
-		auth := couchdb.BasicAuth(test.username, test.password)
+		auth := BasicAuth(test.username, test.password)
 		auth.AddAuth(req)
 
 		expected := http.Header{"Authorization": {test.header}}
@@ -26,7 +25,7 @@ func TestBasicAuth(t *testing.T) {
 
 func TestProxyAuthWithoutToken(t *testing.T) {
 	req, _ := http.NewRequest("GET", "http://localhost/", nil)
-	auth := couchdb.ProxyAuth("user", []string{"role1", "role2"}, "")
+	auth := ProxyAuth("user", []string{"role1", "role2"}, "")
 	auth.AddAuth(req)
 
 	expected := http.Header{
@@ -38,7 +37,7 @@ func TestProxyAuthWithoutToken(t *testing.T) {
 
 func TestProxyAuthWithToken(t *testing.T) {
 	req, _ := http.NewRequest("GET", "http://localhost/", nil)
-	auth := couchdb.ProxyAuth("user", []string{"role1", "role2"}, "secret")
+	auth := ProxyAuth("user", []string{"role1", "role2"}, "secret")
 	auth.AddAuth(req)
 
 	expected := http.Header{

--- a/feeds_test.go
+++ b/feeds_test.go
@@ -1,15 +1,14 @@
-package couchdb_test
+package couchdb
 
 import (
-	"github.com/fjl/go-couchdb"
 	"io"
-	. "net/http"
+	"net/http"
 	"testing"
 )
 
 func TestDBUpdatesFeed(t *testing.T) {
 	c := newTestClient(t)
-	c.Handle("GET /_db_updates", func(resp ResponseWriter, req *Request) {
+	c.Handle("GET /_db_updates", func(resp http.ResponseWriter, req *http.Request) {
 		check(t, "request query string", "feed=continuous", req.URL.RawQuery)
 		io.WriteString(resp, `{
 			"db_name": "db",
@@ -59,7 +58,7 @@ func TestDBUpdatesFeed(t *testing.T) {
 
 func TestChangesFeedPoll(t *testing.T) {
 	c := newTestClient(t)
-	c.Handle("GET /db/_changes", func(resp ResponseWriter, req *Request) {
+	c.Handle("GET /db/_changes", func(resp http.ResponseWriter, req *http.Request) {
 		check(t, "request query string", "", req.URL.RawQuery)
 		io.WriteString(resp, `{
 			"results": [
@@ -117,7 +116,7 @@ func TestChangesFeedPoll(t *testing.T) {
 
 func TestChangesFeedCont(t *testing.T) {
 	c := newTestClient(t)
-	c.Handle("GET /db/_changes", func(resp ResponseWriter, req *Request) {
+	c.Handle("GET /db/_changes", func(resp http.ResponseWriter, req *http.Request) {
 		check(t, "request query string", "feed=continuous", req.URL.RawQuery)
 		io.WriteString(resp, `{
 			"seq": 1,
@@ -136,7 +135,7 @@ func TestChangesFeedCont(t *testing.T) {
 		}`+"\n")
 	})
 
-	feed, err := c.DB("db").Changes(couchdb.Options{"feed": "continuous"})
+	feed, err := c.DB("db").Changes(Options{"feed": "continuous"})
 	if err != nil {
 		t.Fatalf("client.Changes error: %v", err)
 	}

--- a/http.go
+++ b/http.go
@@ -92,9 +92,13 @@ func (t *transport) closedRequest(method, path string, body io.Reader) (*http.Re
 
 func path(segs ...string) string {
 	r := ""
-	for _, seg := range segs {
+	for i, seg := range segs {
 		r += "/"
-		r += url.QueryEscape(seg)
+		if i == 1 && strings.HasPrefix(seg,"_design/") {
+			r += seg
+		} else {
+			r += url.QueryEscape(seg)
+		}
 	}
 	return r
 }

--- a/http_test.go
+++ b/http_test.go
@@ -1,19 +1,19 @@
-package couchdb_test
+package couchdb
 
 import (
-	. "net/http"
+	"net/http"
 	"testing"
 )
 
 type testauth struct{ called bool }
 
-func (a *testauth) AddAuth(*Request) {
+func (a *testauth) AddAuth(*http.Request) {
 	a.called = true
 }
 
 func TestClientSetAuth(t *testing.T) {
 	c := newTestClient(t)
-	c.Handle("HEAD /", func(resp ResponseWriter, req *Request) {})
+	c.Handle("HEAD /", func(resp http.ResponseWriter, req *http.Request) {})
 
 	auth := new(testauth)
 	c.SetAuth(auth)

--- a/http_test.go
+++ b/http_test.go
@@ -33,3 +33,17 @@ func TestClientSetAuth(t *testing.T) {
 		t.Error("AddAuth was called after removing Auth instance")
 	}
 }
+
+func TestPath(t *testing.T) {
+	data := map[string][]string {
+		// Expected output						Input
+		"/foo/bar/baz":							[]string{"foo","bar","baz"},
+		"/foo/_design/bar/_view/baz":			[]string{"foo","_design/bar","_view","baz"},
+	}
+	for expected,segs := range data {
+		result := path(segs...)
+		if result != expected {
+			t.Fatalf("path() produced '%s', expected '%s'", result, expected)
+		}
+	}
+}

--- a/http_test.go
+++ b/http_test.go
@@ -39,6 +39,7 @@ func TestPath(t *testing.T) {
 		// Expected output						Input
 		"/foo/bar/baz":							[]string{"foo","bar","baz"},
 		"/foo/_design/bar/_view/baz":			[]string{"foo","_design/bar","_view","baz"},
+		"/foo%2Fbar/baz%2Fquz":					[]string{"foo/bar","baz/quz"},
 	}
 	for expected,segs := range data {
 		result := path(segs...)


### PR DESCRIPTION
The actual fix is quite small and trivial.  Writing tests to prove the fix was a bit more of a chore, as it involved reorganizing all of the existing tests to run in the same package as couchdb itself.

If you don't like this reorganization, it should be easy enough to apply just the necessary fix--and maybe you can come up with some way to write tests for the unexported `path()` method that fits within your existing test configuration.

This fixes #6.
