### PR TITLE
Add support CouchDB2-style string update sequence.

### DIFF
--- a/couchdb2feed_test.go
+++ b/couchdb2feed_test.go
@@ -1,0 +1,210 @@
+package couchdb_test
+
+// Tests for the CouchDB2/Cloudant specific extensions
+import (
+	"encoding/json"
+	"io"
+
+	. "net/http"
+	"testing"
+
+	"github.com/fjl/go-couchdb"
+)
+
+// TestChangesFeedPollSeqString tests the polled changes feed with a CouchDB2-style
+// seq id - a string.
+func TestChangesFeedPollSeqString(t *testing.T) {
+	c := newTestClient(t)
+	c.Handle("GET /db/_changes", func(resp ResponseWriter, req *Request) {
+		check(t, "request query string", "", req.URL.RawQuery)
+		io.WriteString(resp, `{
+			"results": [
+				{
+					"seq": "1-ba445ec888551c",
+					"id": "doc",
+					"changes": [{"rev":"1-619db7ba8551c0de3f3a178775509611"}]
+				},
+				{
+					"seq": "2-8551c0db7ba8551c0",
+					"id": "doc",
+					"changes": [{"rev":"1-619db7ba8551c0de3f3a178775509611"}]
+				}
+			],
+			"last_seq": "99-7877550961db7b"
+		}`)
+	})
+
+	feed, err := c.DB("db").Changes(nil)
+	if err != nil {
+		t.Fatalf("client.Changes error: %v", err)
+	}
+
+	// TODO: check "changes"
+
+	t.Log("-- first event")
+	check(t, "feed.Next()", true, feed.Next())
+	check(t, "feed.Err()", error(nil), feed.Err())
+
+	check(t, "feed.ID", "doc", feed.ID)
+	if seq, ok := feed.Seq.(string); ok {
+		check(t, "feed.Seq", "1-ba445ec888551c", seq)
+	}
+
+	t.Log("-- second event")
+	check(t, "feed.Next()", true, feed.Next())
+	check(t, "feed.Err()", error(nil), feed.Err())
+
+	check(t, "feed.ID", "doc", feed.ID)
+	if seq, ok := feed.Seq.(string); ok {
+		check(t, "feed.Seq", "2-8551c0db7ba8551c0", seq)
+	}
+
+	t.Log("-- end of feed")
+	check(t, "feed.Next()", false, feed.Next())
+	check(t, "feed.Err()", error(nil), feed.Err())
+
+	check(t, "feed.ID", "", feed.ID)
+	if seq, ok := feed.Seq.(string); ok {
+		check(t, "feed.Seq", "99-7877550961db7b", seq)
+	}
+
+	if err := feed.Close(); err != nil {
+		t.Fatalf("feed.Close error: %v", err)
+	}
+}
+
+// TestChangesFeedPollIncludeDocs tests the 'include_docs' option.
+func TestChangesFeedPollIncludeDocs(t *testing.T) {
+	c := newTestClient(t)
+	c.Handle("GET /db/_changes", func(resp ResponseWriter, req *Request) {
+		check(t, "request query string", "include_docs=true", req.URL.RawQuery)
+		io.WriteString(resp, `{
+			"results": [
+				{
+					"seq": "1-ba445ec888551c",
+					"id": "doc1",
+					"changes": [{"rev":"1-619db7ba8551c0de3f3a178775509611"}],
+					"doc": {
+		        		"_id":"doc1",
+		        		"_rev":"1-619db7ba8551c0de3f3a178775509611",
+		        		"user":"Random J. User1",
+		        		"email":"random1@domain.com",
+		        		"highscore":58
+		    		}
+				},
+				{
+					"seq": "2-8551c0db7ba8551c0",
+					"id": "doc2",
+					"changes": [{"rev":"2-619db7ba8551c0de3f3a178775509611"}],
+					"doc": {
+		        		"_id":"doc2",
+		        		"_rev":"2-619db7ba8551c0de3f3a178775509611",
+		        		"user":"Random J. User2",
+		        		"email":"random2@domain.com",
+		        		"highscore":53
+		    		}
+				}
+			],
+			"last_seq": "99-7877550961db7b"
+		}`)
+	})
+
+	feed, err := c.DB("db").Changes(couchdb.Options{"include_docs": true})
+	if err != nil {
+		t.Fatalf("client.Changes error: %v", err)
+	}
+
+	var doc map[string]interface{}
+
+	t.Log("-- first event")
+	check(t, "feed.Next()", true, feed.Next())
+	check(t, "feed.Err()", error(nil), feed.Err())
+	err = json.Unmarshal([]byte(feed.Doc), &doc)
+	check(t, "Unmarshal doc", true, err == nil)
+	if email, ok := doc["email"].(string); ok {
+		check(t, "doc['email']", "random1@domain.com", email)
+	} else {
+		t.Fatalf("type assertion error")
+	}
+
+	t.Log("-- second event")
+	check(t, "feed.Next()", true, feed.Next())
+	check(t, "feed.Err()", error(nil), feed.Err())
+
+	err = json.Unmarshal([]byte(feed.Doc), &doc)
+	check(t, "Unmarshal doc", true, err == nil)
+	if email, ok := doc["email"].(string); ok {
+		check(t, "doc['email']", "random2@domain.com", email)
+	} else {
+		t.Fatalf("type assertion error")
+	}
+
+	t.Log("-- end of feed")
+	check(t, "feed.Next()", false, feed.Next())
+	check(t, "feed.Err()", error(nil), feed.Err())
+
+	if err := feed.Close(); err != nil {
+		t.Fatalf("feed.Close error: %v", err)
+	}
+}
+
+// TestChangesFeedContSeqString tests the continuous changes feed with a CouchDB2-style
+// seq id - a string.
+func TestChangesFeedContSeqString(t *testing.T) {
+	c := newTestClient(t)
+	c.Handle("GET /db/_changes", func(resp ResponseWriter, req *Request) {
+		check(t, "request query string", "feed=continuous", req.URL.RawQuery)
+		io.WriteString(resp, `{
+			"seq": "1-ba445ec888551c",
+			"id": "doc",
+			"changes": [{"rev":"1-619db7ba8551c0de3f3a178775509611"}]
+		}`+"\n")
+		io.WriteString(resp, `{
+			"seq": "2-8551c0db7ba8551c0",
+			"id": "doc",
+			"changes": [{"rev":"1-619db7ba8551c0de3f3a178775509611"}]
+		}`+"\n")
+		io.WriteString(resp, `{
+			"seq": "99-7877550961db7b",
+			"last_seq": true
+		}`+"\n")
+	})
+
+	feed, err := c.DB("db").Changes(couchdb.Options{"feed": "continuous"})
+	if err != nil {
+		t.Fatalf("client.Changes error: %v", err)
+	}
+
+	// TODO: check "changes"
+
+	t.Log("-- first event")
+	check(t, "feed.Next()", true, feed.Next())
+	check(t, "feed.Err()", error(nil), feed.Err())
+
+	check(t, "feed.ID", "doc", feed.ID)
+	if seq, ok := feed.Seq.(string); ok {
+		check(t, "feed.Seq", "1-ba445ec888551c", seq)
+	}
+
+	t.Log("-- second event")
+	check(t, "feed.Next()", true, feed.Next())
+	check(t, "feed.Err()", error(nil), feed.Err())
+
+	check(t, "feed.ID", "doc", feed.ID)
+	if seq, ok := feed.Seq.(string); ok {
+		check(t, "feed.Seq", "2-8551c0db7ba8551c0", seq)
+	}
+
+	t.Log("-- end of feed")
+	check(t, "feed.Next()", false, feed.Next())
+	check(t, "feed.Err()", error(nil), feed.Err())
+
+	check(t, "feed.ID", "", feed.ID)
+	if seq, ok := feed.Seq.(string); ok {
+		check(t, "feed.Seq", "99-7877550961db7b", seq)
+	}
+
+	if err := feed.Close(); err != nil {
+		t.Fatalf("feed.Close error: %v", err)
+	}
+}

--- a/couchdb_test.go
+++ b/couchdb_test.go
@@ -2,13 +2,14 @@ package couchdb_test
 
 import (
 	"errors"
-	"github.com/fjl/go-couchdb"
 	"io"
 	"io/ioutil"
 	. "net/http"
 	"net/url"
 	"regexp"
 	"testing"
+
+	"github.com/fjl/go-couchdb"
 )
 
 type roundTripperFunc func(*Request) (*Response, error)
@@ -259,6 +260,30 @@ func TestPut(t *testing.T) {
 		t.Fatal(err)
 	}
 	check(t, "returned rev", "1-619db7ba8551c0de3f3a178775509611", rev)
+}
+
+func TestPost(t *testing.T) {
+	c := newTestClient(t)
+	c.Handle("POST /db", func(resp ResponseWriter, req *Request) {
+		body, _ := ioutil.ReadAll(req.Body)
+		check(t, "request body", `{"field":999}`, string(body))
+
+		resp.Header().Set("ETag", `"1-619db7ba8551c0de3f3a178775509611"`)
+		resp.WriteHeader(StatusCreated)
+		io.WriteString(resp, `{
+			"id": "619db7ba8551c0de3f3a178775509611",
+			"ok": true,
+			"rev": "1-619db7ba8551c0de3f3a178775509611"
+		}`)
+	})
+
+	doc := &testDocument{Field: 999}
+	id, rev, err := c.DB("db").Post(doc)
+	if err != nil {
+		t.Fatal(err)
+	}
+	check(t, "returned rev", "1-619db7ba8551c0de3f3a178775509611", rev)
+	check(t, "returned id", "619db7ba8551c0de3f3a178775509611", id)
 }
 
 func TestPutWithRev(t *testing.T) {

--- a/feeds_test.go
+++ b/feeds_test.go
@@ -1,10 +1,12 @@
 package couchdb_test
 
 import (
-	"github.com/fjl/go-couchdb"
 	"io"
+
 	. "net/http"
 	"testing"
+
+	"github.com/fjl/go-couchdb"
 )
 
 func TestDBUpdatesFeed(t *testing.T) {
@@ -67,15 +69,29 @@ func TestChangesFeedPoll(t *testing.T) {
 					"seq": 1,
 					"id": "doc",
 					"deleted": true,
-					"changes": [{"rev":"1-619db7ba8551c0de3f3a178775509611"}]
+					"changes": [{"rev":"1-619db7ba8551c0de3f3a178775509611"}],
+					"doc": {
+		        		"_id":"doc",
+		        		"_rev":"1-619db7ba8551c0de3f3a178775509611",
+		        		"user":"Random J. User",
+		        		"email":"random2@domain.com",
+		        		"highscore":52
+		    		}
 				},
 				{
-					"seq": 2,
+					"seq": "2-hdhff",
 					"id": "doc",
-					"changes": [{"rev":"1-619db7ba8551c0de3f3a178775509611"}]
+					"changes": [{"rev":"1-619db7ba8551c0de3f3a178775509611"}],
+					"doc": {
+		        		"_id":"doc",
+		        		"_rev":"1-619db7ba8551c0de3f3a178775509611",
+		        		"user":"Random J. User",
+		        		"email":"random2@domain.com",
+		        		"highscore":53
+		    		}
 				}
 			],
-			"last_seq": 99
+			"last_seq": "99-kjashdkf"
 		}`)
 	})
 
@@ -91,7 +107,10 @@ func TestChangesFeedPoll(t *testing.T) {
 	check(t, "feed.Err()", error(nil), feed.Err())
 
 	check(t, "feed.ID", "doc", feed.ID)
-	check(t, "feed.Seq", int64(1), feed.Seq)
+	//check(t, "feed.Seq", int64(1), feed.Seq)
+	if seq, ok := feed.Seq.(int64); ok {
+		check(t, "feed.Seq", int64(1), seq)
+	}
 	check(t, "feed.Deleted", true, feed.Deleted)
 
 	t.Log("-- second event")
@@ -99,7 +118,9 @@ func TestChangesFeedPoll(t *testing.T) {
 	check(t, "feed.Err()", error(nil), feed.Err())
 
 	check(t, "feed.ID", "doc", feed.ID)
-	check(t, "feed.Seq", int64(2), feed.Seq)
+	if seq, ok := feed.Seq.(string); ok {
+		check(t, "feed.Seq", "2-hdhff", seq)
+	}
 	check(t, "feed.Deleted", false, feed.Deleted)
 
 	t.Log("-- end of feed")
@@ -107,7 +128,9 @@ func TestChangesFeedPoll(t *testing.T) {
 	check(t, "feed.Err()", error(nil), feed.Err())
 
 	check(t, "feed.ID", "", feed.ID)
-	check(t, "feed.Seq", int64(99), feed.Seq)
+	if seq, ok := feed.Seq.(string); ok {
+		check(t, "feed.Seq", "99-kjashdkf", seq)
+	}
 	check(t, "feed.Deleted", false, feed.Deleted)
 
 	if err := feed.Close(); err != nil {
@@ -123,20 +146,34 @@ func TestChangesFeedCont(t *testing.T) {
 			"seq": 1,
 			"id": "doc",
 			"deleted": true,
-			"changes": [{"rev":"1-619db7ba8551c0de3f3a178775509611"}]
+			"changes": [{"rev":"1-619db7ba8551c0de3f3a178775509611"}],
+			"doc": {
+        		"_id":"doc",
+        		"_rev":"1-619db7ba8551c0de3f3a178775509611",
+        		"user":"Random J. User",
+        		"email":"random2@domain.com",
+        		"highscore":52
+    		}
 		}`+"\n")
 		io.WriteString(resp, `{
-			"seq": 2,
+			"seq": "2-lisdfg",
 			"id": "doc",
-			"changes": [{"rev":"1-619db7ba8551c0de3f3a178775509611"}]
+			"changes": [{"rev":"1-619db7ba8551c0de3f3a178775509611"}],
+			"doc": {
+        		"_id":"doc",
+        		"_rev":"1-619db7ba8551c0de3f3a178775509611",
+        		"user":"Random J. User",
+        		"email":"random2@domain.com",
+        		"highscore":53
+    		}
 		}`+"\n")
 		io.WriteString(resp, `{
-			"seq": 99,
+			"seq": "99-987234982734hjk",
 			"last_seq": true
 		}`+"\n")
 	})
 
-	feed, err := c.DB("db").Changes(couchdb.Options{"feed": "continuous"})
+	feed, err := c.DB("db").Changes(couchdb.Options{"feed": "continuous"}) // add include_docs
 	if err != nil {
 		t.Fatalf("client.Changes error: %v", err)
 	}
@@ -148,7 +185,9 @@ func TestChangesFeedCont(t *testing.T) {
 	check(t, "feed.Err()", error(nil), feed.Err())
 
 	check(t, "feed.ID", "doc", feed.ID)
-	check(t, "feed.Seq", int64(1), feed.Seq)
+	if seq, ok := feed.Seq.(int64); ok {
+		check(t, "feed.Seq", int64(1), seq)
+	}
 	check(t, "feed.Deleted", true, feed.Deleted)
 
 	t.Log("-- second event")
@@ -156,7 +195,10 @@ func TestChangesFeedCont(t *testing.T) {
 	check(t, "feed.Err()", error(nil), feed.Err())
 
 	check(t, "feed.ID", "doc", feed.ID)
-	check(t, "feed.Seq", int64(2), feed.Seq)
+	if seq, ok := feed.Seq.(string); ok {
+		check(t, "feed.Seq", "2-lisdfg", seq)
+	}
+
 	check(t, "feed.Deleted", false, feed.Deleted)
 
 	t.Log("-- end of feed")
@@ -164,7 +206,9 @@ func TestChangesFeedCont(t *testing.T) {
 	check(t, "feed.Err()", error(nil), feed.Err())
 
 	check(t, "feed.ID", "", feed.ID)
-	check(t, "feed.Seq", int64(99), feed.Seq)
+	if seq, ok := feed.Seq.(string); ok {
+		check(t, "feed.Seq", "99-987234982734hjk", seq)
+	}
 	check(t, "feed.Deleted", false, feed.Deleted)
 
 	if err := feed.Close(); err != nil {

--- a/http.go
+++ b/http.go
@@ -68,6 +68,7 @@ func (t *transport) newRequest(method, path string, body io.Reader) (*http.Reque
 // Status codes >= 400 are treated as errors.
 func (t *transport) request(method, path string, body io.Reader) (*http.Response, error) {
 	req, err := t.newRequest(method, path, body)
+	req.Header.Add("Content-Type", "application/json") // Required for POST
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
_What_

Cloudant (and the soon to be released CouchDB2) has a different format for the update sequence
compared with CouchDB1.X. In CouchDB1, this was an integer, but in CouchDB2 and its derivatives,
this is an opaque string:

{"results":[
{"seq":
    "1-g1AAAAEceJzLYWBgYMlgTmGQS0lKzi9KdUhJMtIryC8qSS3SS87JL01JzCvRy0styQGqY0pkSLL___
    9_ViIDqg5DnDqSHIBkUj1IUwZzImMukMdubmSaZmFiStAAYu3IYwGSDA1ACmjNfhIcB9F4AKIR6ECg_8AOTDY1sr
    RINcoCAChmW4s",
"id":
    "4855590576c378f78af56f33222c50d1",
"changes":[{
    "rev":"1-b3ef851824b8b32c215e651c32fb0be0"
}]}, ...etc

This makes go-couchdb also compatible with Cloudant and CouchDB2.

In order to pull out `Seq` with the appropriate type, use:

if feed, err := c.DB("db").Changes(nil); err == nil {
    feed.Next()
    if seq, ok := feed.Seq.(int64); ok {
        // seq is int64...
    }
}

Also added a Post().

_How_
- The type of the `Seq` in the ChangesFeed struct was changed from int64 to interface{} so that it can
  represent both flavours.
- `func (f *ChangesFeed) contParser(r io.Reader)` was changed to reflect this type change, and also extended
  with `Changes` and `Doc` fields so that it also works with `include_docs=true`.
- `func (f *ChangesFeed) pollParser(scan *scanner)` was extended to cater for both types of `last_seq`.

_Testing_

Tests in couchdb2feed_test.go to test the string seq. Added a test for Post(). 
